### PR TITLE
Remove everything related to seeds; we don't do that anymore!

### DIFF
--- a/R/audit.R
+++ b/R/audit.R
@@ -179,8 +179,7 @@ audit <- function(data, uname, m0, m1, pm0, pm1, splinesobj,
                   lpsolver, lpsolver.options, lpsolver.presolve,
                   lpsolver.options.criterion, lpsolver.options.bounds,
                   smallreturnlist = FALSE,
-                  noisy = TRUE, seed = 12345, debug = FALSE) {
-    set.seed(seed)
+                  noisy = TRUE, debug = FALSE) {
     call  <- match.call()
     lpsolver <- tolower(lpsolver)
     ## Set the audit tolerance

--- a/tests/testthat/test_covariates.R
+++ b/tests/testthat/test_covariates.R
@@ -34,8 +34,7 @@ result <- ivmte(ivlike = ivlike,
                 m1.inc = TRUE,
                 mte.dec = TRUE,
                 treat = d,
-                lpsolver = "lpSolveAPI",
-                seed = 10L)
+                lpsolver = "lpSolveAPI")
 
 ##------------------------
 ## Implement test

--- a/tests/testthat/test_single.R
+++ b/tests/testthat/test_single.R
@@ -25,8 +25,7 @@ result <- ivmte(ivlike = ey ~ 1 +d + x1 + x2,
                 initgrid.nx = 2,
                 audit.nx = 5,
                 audit.nu = 5,
-                lpsolver = "lpSolveAPI",
-                seed = 10L)
+                lpsolver = "lpSolveAPI")
 
 ##------------------------
 ## Implement test

--- a/tests/testthat/test_splines.R
+++ b/tests/testthat/test_splines.R
@@ -36,8 +36,7 @@ result <- ivmte(ivlike = ivlike,
                 m1.ub = 55,
                 m0.lb = 0,
                 mte.inc = TRUE,
-                lpsolver = "lpSolveAPI",
-                seed = 10L)
+                lpsolver = "lpSolveAPI")
 
 ##-------------------------
 ## Perform tests
@@ -410,8 +409,7 @@ resultAlt <- ivmte(ivlike = ivlike,
                    m0.lb = 0,
                    mte.inc = TRUE,
                    mte.ub = 10,
-                   lpsolver = "lpSolveAPI",
-                   seed = 10L)
+                   lpsolver = "lpSolveAPI")
 
 ##------------------------
 ## Reconstruct target gamma moments


### PR DESCRIPTION
`ivmte` no longer screws up the random number generator


```r
devtools::load_all()

data <- read.csv("./mwe1.csv")

args <- list(data = data, ivlike = y ~ d*factor(z),
             target = "ate",
             m0 = ~ 1,
             m1 = ~ u,
             m0.lb = 0,
             m0.ub = 0,
             propensity = d ~ factor(z))

for (i in 1:3) {
    print(rnorm(1))
    do.call(ivmte, args)
}
```
gives
```r
[1] 0.2428141
[1] -0.1794061
[1] -0.6305186
```

And we still get reproducibility by setting the seed before calling it
```r
# audit is stable
set.seed(2)
print(do.call(ivmte, args)$bounds)

set.seed(2)
print(do.call(ivmte, args)$bounds)

# bootstrap also stable
args[["bootstraps"]] <- 20
set.seed(2)
r <- do.call(ivmte, args)
print(r$bounds.ci)

set.seed(2)
r <- do.call(ivmte, args)
print(r$bounds.ci)
```
yields
```r
[1] 0.2727059 0.2727059
[1] 0.2727059 0.2727059
$backward
     lb.backward ub.backward
0.9    0.1117307   0.5199328
0.95   0.1117307   0.5202089
0.99   0.1117307   0.5202089

$forward
     lb.forward ub.forward
0.9  0.02547898  0.4336811
0.95 0.02520293  0.4336811
0.99 0.02520293  0.4336811

$backward
     lb.backward ub.backward
0.9    0.1117307   0.5199328
0.95   0.1117307   0.5202089
0.99   0.1117307   0.5202089

$forward
     lb.forward ub.forward
0.9  0.02547898  0.4336811
0.95 0.02520293  0.4336811
0.99 0.02520293  0.4336811
```